### PR TITLE
Add license file and example link to readme. 

### DIFF
--- a/LICENSE.md
+++ b/LICENSE.md
@@ -1,0 +1,7 @@
+Copyright 2020 Jason Sadler
+
+Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated documentation files (the "Software"), to deal in the Software without restriction, including without limitation the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.

--- a/README.md
+++ b/README.md
@@ -3,11 +3,13 @@ Script that allows facial expressions and visemes on Adobe Fuse CC created chara
 
 <h2>Known Issues</h2>
 
-This is a rough alpha version and a proof of concept only. Clean up and optimization will follow. It is tested and works with characters created in Adobe Fuse CC and rigged using the Mixamo auto-rigger with BlendShapes added. It is untested for characters created and rigged through Mixamo Fuse 1.3.
+This is a rough alpha version and a proof of concept only. It is tested and works with characters created in Adobe Fuse CC and rigged using the Mixamo auto-rigger with BlendShapes added. It is untested for characters created and rigged through Mixamo Fuse 1.3.
 
 Currently BlendShape names are hardcoded. Updates will grab the BlendShape names from the SkinnedMeshRenderer.
 
-<h2>Instructions</h2>
+<h2>Example</h2>
+
+See https://www.youtube.com/watch?v=U59znmXhK64 for example of usage.
 
 
 


### PR DESCRIPTION
Resolves #2.

Adds MIT license and also adding youtube link demonstrating usage.

https://www.youtube.com/watch?v=U59znmXhK64

This was created end of 2016/beginning of 2017 for Unity 5 and Unity 2017. I have no idea on the status of later versions.